### PR TITLE
Fixed unexpected modification of input bitmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ backpack.on('ready', function() {
 
 &#x20;<a href="#api-backpack-animate-callback-err" name="api-backpack-clear-callback-err">#</a> backpack<b>.animate</b> ( frames, interval ) renders each frame in order with a separation in ms equal to the interval
 
+&#x20;<a href="#api-backpack-scroll-callback-err" name="api-backpack-clear-callback-err">#</a> backpack<b>.scroll</b> ( bitmap, interval ) scrolls the bitmap horizontally with a separation between frames in ms equal to the interval. Bitmap can be any width
+
 ###Events
 &#x20;<a href="#api-backpack-on-error-callback-err-Emitted-upon-error" name="api-backpack-on-error-callback-err-Emitted-upon-error">#</a> backpack<b>.on</b>( 'error', callback(err) ) Emitted upon error.
 

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ Backpack.prototype.writeBitmap = function(bitmap, callback) {
   var self = this;
 
   bitmap.forEach(function(row, index) {
-    var rowBuffer = row.slice();
+    var rowBuffer = row.slice().reverse();
     rowBuffer.unshift(rowBuffer.pop());
     var rowValue = parseInt(rowBuffer.join(""), 2);
     self.i2c.send(new Buffer([index*2 & 0xFF, rowValue]), self._errorCallback);

--- a/index.js
+++ b/index.js
@@ -66,8 +66,9 @@ Backpack.prototype.writeBitmap = function(bitmap, callback) {
   var self = this;
 
   bitmap.forEach(function(row, index) {
-    row.unshift(row.pop());
-    var rowValue = parseInt(row.join(""), 2);
+    var rowBuffer = row.slice();
+    rowBuffer.unshift(rowBuffer.pop());
+    var rowValue = parseInt(rowBuffer.join(""), 2);
     self.i2c.send(new Buffer([index*2 & 0xFF, rowValue]), self._errorCallback);
   });
 }

--- a/index.js
+++ b/index.js
@@ -89,6 +89,37 @@ Backpack.prototype._animate = function(frames, interval) {
   }
 }
 
+Backpack.prototype.scroll = function(bitmap, interval) {
+  var self = this;
+
+  var length = bitmap[0].length;
+
+  var paddedBitmap = [];
+
+  bitmap.forEach(function(row,index) {
+      paddedBitmap[index] = row.slice();
+      paddedBitmap[index].push.apply(paddedBitmap[index],[0,0,0,0,0,0,0,0]);
+      paddedBitmap[index].unshift(0,0,0,0,0,0,0,0);
+    });
+
+  var n = 0;
+  var writeScroll = function() {
+    var currentBitmap = [];
+
+    paddedBitmap.forEach(function(row,index) {
+      currentBitmap[index] = row.slice(0,8);
+      row.shift();
+    });
+
+    self.writeBitmap(currentBitmap);
+
+    n++;
+    if(n<=length+8) setTimeout(writeScroll, interval);
+  }
+
+  setTimeout(writeScroll, interval);
+}
+
 function use(hardware, callback) {
   return new Backpack(hardware, callback);
 }


### PR DESCRIPTION
When writeBitmap is called "row.unshift(row.pop());" modifies the array
object that is passed to writeBitmap. If the bitmap is only used once it
is OK, however if the bitmap is to be reused it is unexpectedly shifted
each time writeBitmap is called. This commit prevents this from
happening.
